### PR TITLE
Modify _GetCurrencyInfoByName return

### DIFF
--- a/DataStore_Currencies/Changelog.txt
+++ b/DataStore_Currencies/Changelog.txt
@@ -2,6 +2,11 @@ DataStore Changelog (dates in dd/mm/yyyy)
 ===================
 
 
+Version 2025.08.21 (21/08/2025)
+
+- Added 11.2 currencies.
+- Updated ToC for Mists of Pandaria and 11.2.
+
 Version 2025.02.28 (28/02/2025)
 
 - Added 11.1 currencies.

--- a/DataStore_Currencies/DataStore_Currencies.lua
+++ b/DataStore_Currencies/DataStore_Currencies.lua
@@ -405,6 +405,7 @@ local function _GetCurrencyInfoByName(character, token)
 			return name, count, info, category
 		end
 	end
+	return token, nil, currenciesInfo[currenciesCatalog.Set[token]], nil
 end
 
 -- normally not necessary anymore, needs testing

--- a/DataStore_Currencies/DataStore_Currencies.lua
+++ b/DataStore_Currencies/DataStore_Currencies.lua
@@ -561,7 +561,7 @@ AddonFactory:OnPlayerLogin(function()
 	end
 	
 	-- Hook the Confirm button to get the sourceGUID BEFORE the transfer occurs.
-	CurrencyTransferMenu.ConfirmButton:HookScript("PreClick", function(self) 
+	CurrencyTransferMenu.Content.ConfirmButton:HookScript("PreClick", function(self) 
 		local data = CurrencyTransferMenu:GetSourceCharacterData()
 	
 		if data then
@@ -570,3 +570,4 @@ AddonFactory:OnPlayerLogin(function()
 	end)	
 	
 end)
+

--- a/DataStore_Currencies/DataStore_Currencies.lua
+++ b/DataStore_Currencies/DataStore_Currencies.lua
@@ -405,6 +405,7 @@ local function _GetCurrencyInfoByName(character, token)
 			return name, count, info, category
 		end
 	end
+	
 	return token, nil, currenciesInfo[currenciesCatalog.Set[token]], nil
 end
 
@@ -570,4 +571,3 @@ AddonFactory:OnPlayerLogin(function()
 	end)	
 	
 end)
-

--- a/DataStore_Currencies/DataStore_Currencies.toc
+++ b/DataStore_Currencies/DataStore_Currencies.toc
@@ -1,4 +1,4 @@
-## Interface: 110100, 40400
+## Interface: 110200, 40400
 ## Title: DataStore_Currencies
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 

--- a/DataStore_Currencies/DataStore_Currencies.toc
+++ b/DataStore_Currencies/DataStore_Currencies.toc
@@ -1,10 +1,10 @@
-## Interface: 110200, 40400
+## Interface: 110200, 50500
 ## Title: DataStore_Currencies
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 
 ## Notes: Stores information about character currencies
 ## Author: Thaoky (EU-Marécages de Zangar)
-## Version: 2025.02.28
+## Version: 2025.08.21
 ## Dependencies: AddonFactory, DataStore
 ## SavedVariables: DataStore_Currencies_Characters, DataStore_Currencies_Catalog, DataStore_Currencies_Info, DataStore_Currencies_Max, DataStore_Currencies_Headers, DataStore_Currencies_Archeology 
 ## X-Category: Interface Enhancements

--- a/DataStore_Currencies/Enum.lua
+++ b/DataStore_Currencies/Enum.lua
@@ -118,4 +118,10 @@ enum.CurrencyIDs = {
 	CarvedUndermineCrest = 3108,
 	RunedUndermineCrest = 3109,
 	GildedUndermineCrest = 3110,	
+	
+	-- War Within 11.2
+	WeatheredEtherealCrest = 3284,
+	CarvedEtherealCrest = 3286,
+	RunedEtherealCrest = 3288,
+	GildedEtherealCrest = 3290,	
 }


### PR DESCRIPTION
Modified _GetCurrencyInfoByName return values to at least return the token queried and the texture known by the system (allows for Altoholic_Grids to display information easier)