### PR TITLE
Debounce CURRENCY_DISPLAY_UPDATE + secret-string guard + toc 120005

### DIFF
--- a/DataStore_Currencies/DataStore_Currencies.lua
+++ b/DataStore_Currencies/DataStore_Currencies.lua
@@ -269,14 +269,39 @@ local function OnPlayerAlive()
 	ScanCurrencies()
 end
 
-local function OnCurrencyDisplayUpdate(event, currencyID)
-	if isRetail then ScanHiddenCurrency(currencyID) end
+-- CURRENCY_DISPLAY_UPDATE fires multiple times in quick succession when the
+-- player gains currency (especially during weekly cap rollovers / multi-quest
+-- turn-ins). On 12.0+ retail with 200+ entries, ScanCurrencies's three-pass
+-- structure (SaveHeaders -> walk full list -> RestoreHeaders) is heavy enough
+-- that running it on every event is the single biggest sync hit per currency
+-- change. Coalesce the events with a 1s debounce: the first event schedules a
+-- single scan, subsequent events within that window are no-ops.
+local currencyScanPending
+local pendingHiddenIDs
 
-	ScanCurrencies()
-	
-	if isRetail then
-		ScanArcheology()
+local function OnCurrencyDisplayUpdate(event, currencyID)
+	if isRetail and currencyID then
+		pendingHiddenIDs = pendingHiddenIDs or {}
+		pendingHiddenIDs[currencyID] = true
 	end
+
+	if currencyScanPending then return end
+	currencyScanPending = true
+	C_Timer.After(1, function()
+		currencyScanPending = nil
+		if isRetail and pendingHiddenIDs then
+			for id in pairs(pendingHiddenIDs) do
+				ScanHiddenCurrency(id)
+			end
+			pendingHiddenIDs = nil
+		end
+
+		ScanCurrencies()
+
+		if isRetail then
+			ScanArcheology()
+		end
+	end)
 end
 
 

--- a/DataStore_Currencies/DataStore_Currencies.lua
+++ b/DataStore_Currencies/DataStore_Currencies.lua
@@ -371,7 +371,9 @@ local function OnCurrencyTransferLogUpdate()
 end
 
 local function OnChatMsgSystem(event, arg)
-	if arg and arg == ITEM_REFUND_MSG then
+	-- In WoW 12.0+, CHAT_MSG_SYSTEM args may be secret strings that cannot be compared by addons
+	local ok, isMatch = pcall(function() return arg == ITEM_REFUND_MSG end)
+	if ok and isMatch then
 		ScanCurrencies()
 		ScanArcheology()
 	end

--- a/DataStore_Currencies/DataStore_Currencies.toc
+++ b/DataStore_Currencies/DataStore_Currencies.toc
@@ -1,4 +1,4 @@
-## Interface: 120000, 50501
+## Interface: 120000, 50501, 120005
 ## Title: DataStore_Currencies
 ## IconTexture: Interface\Icons\garrison_building_storehouse
 


### PR DESCRIPTION
## Summary
- **Debounce CURRENCY_DISPLAY_UPDATE** with a 1s coalescing window. The event fan-outs heavily during multi-quest turn-ins and weekly cap rollovers, and ScanCurrencies is a three-pass operation (SaveHeaders expand-all -> walk 200+ entries -> RestoreHeaders collapse) on 12.0+ retail. Running it on every event is the single biggest sync hit per currency change.
- **Pcall the ITEM_REFUND_MSG comparison** in OnChatMsgSystem - CHAT_MSG_SYSTEM args may be secret strings in 12.0+ and direct equality compare taints. The listener is currently commented out at the registration site (line 550), so this is dead-code today but applies when re-enabled.
- **Declare 12.0.5 in toc**.

## Behaviour
- The very first CURRENCY_DISPLAY_UPDATE in a 1s window schedules the scan; subsequent events are no-ops, but their `currencyID` is still tracked in a pending set so `ScanHiddenCurrency(id)` is called once per unique ID when the timer fires.
- The actual ScanCurrencies three-pass body is unchanged - this PR addresses the trigger frequency, not the scan cost itself. (Chunking the three passes is doable but invasive because of the header expand/collapse round-trip; deferred unless burst events alone don't relieve the budget pressure.)

## Test plan
- [ ] Hand in a Khaz Algar quest that grants 5+ currencies - only one ScanCurrencies runs (was 5+).
- [ ] Daily/weekly reset cap update - one scan, not N.
- [ ] Currency transfer logs still fire correctly via OnCurrencyTransferLogUpdate (untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)